### PR TITLE
support passing -Dsystem.property=value to bootRun task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,3 +87,26 @@ dependencies {
 springBoot {
 	mainClass = "com.yotouch.base.PylonApplication"
 }
+
+//bootRun {
+//    // support passing -Dsystem.property=value to bootRun task
+//	systemProperties System.properties
+//}
+
+// see http://mrhaki.blogspot.com/2015/09/grails-goodness-passing-system.html
+// we configure the run and bootRun tasks and use System.properties with the Java system properties from the command-line as argument for the systemProperties method:
+[bootRun].each { runTask ->
+    configure(runTask) {
+        systemProperties System.properties
+    }
+}
+
+// see http://mrhaki.blogspot.com/2015/09/gradle-goodness-pass-java-system.html
+// The run task added by the application plugin
+// is also of type JavaExec.
+//tasks.withType(JavaExec) {
+//    // Assign all Java system properties from
+//    // the command line to the JavaExec task.
+//    systemProperties System.properties
+//}
+

--- a/src/main/java/com/yotouch/core/config/ConfigureImpl.java
+++ b/src/main/java/com/yotouch/core/config/ConfigureImpl.java
@@ -45,6 +45,7 @@ public class ConfigureImpl implements Configure {
             logger.info("Get YT_HOME from environment: " + ytRuntimeHome);
 
             if (ytRuntimeHome == null) {
+                this.ytHome = new File(System.getProperty("user.dir"));
                 /*
                 URL location = ConfigureImpl.class.getProtectionDomain().getCodeSource().getLocation();
                 this.ytHome = new File(location.getFile());

--- a/src/main/java/com/yotouch/core/config/ConfigureImpl.java
+++ b/src/main/java/com/yotouch/core/config/ConfigureImpl.java
@@ -45,8 +45,8 @@ public class ConfigureImpl implements Configure {
             logger.info("Get YT_HOME from environment: " + ytRuntimeHome);
 
             if (ytRuntimeHome == null) {
-                this.ytHome = new File(System.getProperty("user.dir"));
                 /*
+                this.ytHome = new File(System.getProperty("user.dir"));
                 URL location = ConfigureImpl.class.getProtectionDomain().getCodeSource().getLocation();
                 this.ytHome = new File(location.getFile());
                 */


### PR DESCRIPTION
有几种不同的方式来增加对 -D传递 property的支持
已经用注释写了 包括来源 
自己试了前两种
第三种看不太懂，因为不知道withType的入参应该是什么

第二种应该比较灵活，可以多个task都应用到

另外，我在configure中初始化时，如果没有传-DYT_HOME 会直接使用user.dir
当然，这个也不能保证一定就在当前目录下运行。

以上。