### PR TITLE
add datetime format yyyy-MM-dd for parse date string

### DIFF
--- a/src/main/java/com/yotouch/core/util/DateTimeUtil.java
+++ b/src/main/java/com/yotouch/core/util/DateTimeUtil.java
@@ -16,6 +16,7 @@ public class DateTimeUtil {
             new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"),
             new SimpleDateFormat("yyyy-MM-dd HH:mm"),
             new SimpleDateFormat("yyyyMMddHHmmss"),
+            new SimpleDateFormat("yyyy-MM-dd"),
     };
 
     static final SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd");


### PR DESCRIPTION
post来'2016-12-23'这样datetime时，无法自动parse成功。